### PR TITLE
Shelf aware runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,17 @@ Displays a list of the activated endpoints in the engine.
 - Sets the location of the objects' code storage directory. 
 - Default: `shelf`
 - Note: If this variable is set to the activator's shelf, the runtime will use the existing artifacts for the activation, without the need to fetch them through the `/proxy/artifacts` endpoints.
-  
+
+### `NODE_PATH`
+- Sets the system location for installing node modules specified in package.json files inside KO's.
+- Default: none
+- If using a released version of the node runtime, you must set `NODE_PATH` to `kgrid_node/node_modules` in the current directory. Otherwise, your KO's will not be able to require node packages.
+    - Unix: `export NODE_PATH=$(pwd)/kgrid_node/node_modules`
+    - Windows: `set NODE_PATH=%cd%\kgrid_node\node_modules`
+
 ### `DEBUG`
 - Changes the logging level to debug, takes a boolean `true`/`false`
 - Default: `false`
-
 
 ## Start the runtime
 

--- a/README.md
+++ b/README.md
@@ -53,26 +53,6 @@ Displays a list of the activated endpoints in the engine.
 - The interval (in seconds) of the heartbeat when this runtime will ping and try to reconnect to the activator. The value of 0 or negative number will disable the heartbeat.
 - Default value:`30`
 
-### `ACTIVATE_ON_STARTUP`
-- if `TRUE`
-  - Activate everything in `context.json`
-- if `FALSE`
-  - activate only on receipt of activation messages
-
-     
-### `USE_CACHED_ENDPOINTS`
-- if `TRUE`
-    - On activation message (or at startup)
-      - if in memory done
-      - else activate from local, remote, proxy, and update in `context.json` 
-- `FALSE`
-    - At startup delete "local" artifacts and `context.json`
-    - On activation message or startup 
-      - if in memory discard and (re)activate
-      - if not, activate 
-      - always update local cache and `context.json`
-
-
 ### `KGRID_NODE_CACHE_STRATEGY` (What is the startup behavior?)
 - Sets if the objects are cached or overwritten on each activation call. Can take three values: `never`, `always`, or `use_checksum`
 

--- a/README.md
+++ b/README.md
@@ -62,16 +62,13 @@ Displays a list of the activated endpoints in the engine.
 - Default value: `never`
 
 ### `KGRID_NODE_SHELF_PATH`
-- Sets the location of the objects' code storage directory.
+- Sets the location of the objects' code storage directory. 
 - Default: `shelf`
-
+- Note: If this variable is set to the activator's shelf, the runtime will use the existing artifacts for the activation, without the need to fetch them through the `/proxy/artifacts` endpoints.
+  
 ### `DEBUG`
 - Changes the logging level to debug, takes a boolean `true`/`false`
 - Default: `false`
-
-### `NODE_PATH`
-- Specifies the relative path for the alternative location where the dependencies are installed 
-- Default: `kgrid_node/node_modules`
 
 
 ## Start the runtime

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Displays a list of the activated endpoints in the engine.
 - Changes the logging level to debug, takes a boolean `true`/`false`
 - Default: `false`
 
+### `NODE_PATH`
+- Specifies the relative path for the alternative location where the dependencies are installed 
+- Default: `kgrid_node/node_modules`
+
+
 ## Start the runtime
 
 Start the runtime by running

--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@ const kgridProxyAdapterUrl = require('./lib/paths').kgridProxyAdapterUrl;
 const environmentSelfUrl = require('./lib/paths').environmentSelfUrl;
 const shelfPath = require('./lib/paths').shelfPath;
 const contextFilePath = require('./lib/paths').contextFilePath;
-const packageFilePath = require('./lib/paths').packageFilePath;
 
 let app = express();
 
@@ -42,10 +41,6 @@ function checkPaths() {
     if (!fs.pathExistsSync(contextFilePath)) {
         fs.ensureFileSync(contextFilePath)
         fs.writeJSONSync(contextFilePath, {}, {spaces: 4})
-    }
-    if (!fs.pathExistsSync(packageFilePath)) {
-        fs.ensureFileSync(packageFilePath)
-        fs.writeJSONSync(packageFilePath, {"name": "expressActivatorShelf"}, {spaces: 4})
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -54,7 +54,6 @@ function setUpExpressApp() {
     app.locals.info.engine = "node";
     app.locals.info.status = "up";
     app.locals.needsRefresh = true;
-    fs.createWriteStream(path.join(__dirname, 'access.log'), {flags: 'a'});
     app.set('views', path.join(__dirname, 'views'));
     app.set('view engine', 'pug');
     app.use(cors());

--- a/lib/activation.js
+++ b/lib/activation.js
@@ -1,7 +1,7 @@
 const URI = require('uri-js');
 const path = require('path');
 const executor = require('./executor');
-const downloadAsset = require('./downloadasset');
+const {download_files} = require('./downloadasset');
 const fs = require('fs-extra');
 const log = require('./logger')
 const installDependencies = require('./dependencies')
@@ -10,12 +10,7 @@ const shelfPath = require('./paths').shelfPath
 
 module.exports = function (baseUrl, id, req, res, result) {
     let koAddress = URI.parse(baseUrl).path.split("/proxy/artifacts/").pop();
-    downloadAsset.cleanup(shelfPath, id);
-    // if(shelfPath === process.env.KGRID_NODE_SHELF_PATH){
-    //     // find artifacts on the shelf
-    //     // install dependencies
-    // } else {
-    Promise.all(downloadAsset.download_files(baseUrl, req.body.artifact, shelfPath, koAddress))
+    Promise.all(download_files(baseUrl, req.body.artifact, shelfPath, koAddress))
         .then(function (artifacts) {
             let activationResult = activateArtifacts(artifacts, koAddress, id, req)
             result.status = activationResult.description
@@ -23,7 +18,6 @@ module.exports = function (baseUrl, id, req, res, result) {
         })
         .catch(function (errors) {
             setTimeout(function () {
-                downloadAsset.cleanup(shelfPath, id);
                 global.cxt.map[id] = {
                     executor: null,
                     activated: new Date(),
@@ -32,12 +26,10 @@ module.exports = function (baseUrl, id, req, res, result) {
                     isProcessing: false
                 };
                 fs.writeJSONSync(contextFilePath, global.cxt.map, {spaces: 4});
-
                 result.status = ' Cannot download ' + errors
                 res.status(404).json(result)
             }, 500);
         });
-    // }
     return result;
 }
 
@@ -81,7 +73,6 @@ function activateArtifacts(artifacts, koAddress, id, request) {
     } catch (error) {
         log('warn', error.message)
         log('debug', error);
-        downloadAsset.cleanup(shelfPath, id);
         endpoint.status = error.message
         result = {
             status: 400,

--- a/lib/activation.js
+++ b/lib/activation.js
@@ -78,7 +78,6 @@ function activateArtifacts(artifacts, koAddress, id, request) {
             status: 400,
             description: " Cannot create executor." + error, "stack": error.stack
         }
-        console.log("=====> " + require.resolve.paths('number-string'))
     } finally {
         global.cxt.map[id] = endpoint
         global.cxt.map[id].isProcessing = false

--- a/lib/activation.js
+++ b/lib/activation.js
@@ -78,6 +78,7 @@ function activateArtifacts(artifacts, koAddress, id, request) {
             status: 400,
             description: " Cannot create executor." + error, "stack": error.stack
         }
+        console.log("=====> " + require.resolve.paths('number-string'))
     } finally {
         global.cxt.map[id] = endpoint
         global.cxt.map[id].isProcessing = false

--- a/lib/activation.js
+++ b/lib/activation.js
@@ -1,0 +1,96 @@
+const URI = require('uri-js');
+const path = require('path');
+const executor = require('./executor');
+const downloadAsset = require('./downloadasset');
+const fs = require('fs-extra');
+const log = require('./logger')
+const installDependencies = require('./dependencies')
+const contextFilePath = require('./paths').contextFilePath
+const shelfPath = require('./paths').shelfPath
+
+module.exports = function (baseUrl, id, req, res, result) {
+    let koAddress = URI.parse(baseUrl).path.split("/proxy/artifacts/").pop();
+    downloadAsset.cleanup(shelfPath, id);
+    // if(shelfPath === process.env.KGRID_NODE_SHELF_PATH){
+    //     // find artifacts on the shelf
+    //     // install dependencies
+    // } else {
+    Promise.all(downloadAsset.download_files(baseUrl, req.body.artifact, shelfPath, koAddress))
+        .then(function (artifacts) {
+            let activationResult = activateArtifacts(artifacts, koAddress, id, req)
+            result.status = activationResult.description
+            res.status(activationResult.status).json(result)
+        })
+        .catch(function (errors) {
+            setTimeout(function () {
+                downloadAsset.cleanup(shelfPath, id);
+                global.cxt.map[id] = {
+                    executor: null,
+                    activated: new Date(),
+                    id: id,
+                    status: errors,
+                    isProcessing: false
+                };
+                fs.writeJSONSync(contextFilePath, global.cxt.map, {spaces: 4});
+
+                result.status = ' Cannot download ' + errors
+                res.status(404).json(result)
+            }, 500);
+        });
+    // }
+    return result;
+}
+
+
+function activateArtifacts(artifacts, koAddress, id, request) {
+    let result;
+    artifacts.forEach(function (artifact) {
+        let packageFile = path.basename(artifact);
+        if (packageFile === "package.json") {
+            log('info', packageFile);
+            let pkgJson = require(path.join(shelfPath, koAddress, packageFile));
+            let dependencies = pkgJson.dependencies;
+            if (dependencies) {
+                log('info', dependencies);
+                installDependencies(dependencies);
+            }
+        }
+    });
+    let entryFile = path.join(shelfPath, koAddress, request.body.entry);
+    let endpoint = {
+        entry: entryFile,
+        executor: null,
+        activated: new Date(),
+        id: id,
+        status: 'Not Activated',
+        checksum: request.body.checksum
+    }
+
+    try {
+        let exec = Object.create(executor);
+        exec.init(entryFile);
+        endpoint.executor = exec;
+        endpoint.status = 'Activated';
+
+        log('info', `Successfully deployed endpoint: ${endpoint.id}`);
+        log('debug', request.body);
+        result = {
+            status: 200,
+            description: ' Success'
+        }
+    } catch (error) {
+        log('warn', error.message)
+        log('debug', error);
+        downloadAsset.cleanup(shelfPath, id);
+        endpoint.status = error.message
+        result = {
+            status: 400,
+            description: " Cannot create executor." + error, "stack": error.stack
+        }
+    } finally {
+        global.cxt.map[id] = endpoint
+        global.cxt.map[id].isProcessing = false
+        fs.writeJSONSync(contextFilePath, global.cxt.map, {spaces: 4});
+    }
+    return result;
+}

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,20 +1,16 @@
 const shelljs = require('shelljs');
-const path = require('path');
-const shelfPath = require('./paths').shelfPath
 const installationPath = require('./paths').installationPath
-const moduleParentPath = path.dirname(installationPath)
 
 module.exports =
     function (dependencies) {
-        shelljs.cd(shelfPath);
         let hasError = false;
         for (let key in dependencies) {
             if (dependencies[key].startsWith('http') || dependencies[key].startsWith('https')) {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${moduleParentPath} --no-package-lock ` + dependencies[key]))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${installationPath} --no-package-lock ` + dependencies[key]))) {
                     hasError = true;
                 }
             } else {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${moduleParentPath} --no-package-lock ` + key))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${installationPath} --no-package-lock ` + key))) {
                     hasError = true;
                 }
             }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,0 +1,20 @@
+const shelljs = require('shelljs');
+const shelfPath = require('./paths').shelfPath
+
+module.exports =
+    function (dependencies) {
+        shelljs.cd(shelfPath);
+        let hasError = false;
+        for (let key in dependencies) {
+            if (dependencies[key].startsWith('http') || dependencies[key].startsWith('https')) {
+                if (shelljs.error(shelljs.exec('npm install --save ' + dependencies[key]))) {
+                    hasError = true;
+                }
+            } else {
+                if (shelljs.error(shelljs.exec('npm install --save ' + key))) {
+                    hasError = true;
+                }
+            }
+        }
+        return hasError;
+    }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,17 +1,20 @@
 const shelljs = require('shelljs');
+const path = require('path');
 const shelfPath = require('./paths').shelfPath
 const nodePath = require('./paths').nodePath
+const moduleParentPath = path.dirname(nodePath)
 module.exports =
     function (dependencies) {
+        console.log(" **************  Node Path: "+ nodePath)
         shelljs.cd(shelfPath);
         let hasError = false;
         for (let key in dependencies) {
             if (dependencies[key].startsWith('http') || dependencies[key].startsWith('https')) {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --no-package-lock ` + dependencies[key]))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${moduleParentPath} --no-package-lock ` + dependencies[key]))) {
                     hasError = true;
                 }
             } else {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --no-package-lock ` + key))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${moduleParentPath} --no-package-lock ` + key))) {
                     hasError = true;
                 }
             }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,17 +1,17 @@
 const shelljs = require('shelljs');
 const shelfPath = require('./paths').shelfPath
-
+const nodePath = require('./paths').nodePath
 module.exports =
     function (dependencies) {
         shelljs.cd(shelfPath);
         let hasError = false;
         for (let key in dependencies) {
             if (dependencies[key].startsWith('http') || dependencies[key].startsWith('https')) {
-                if (shelljs.error(shelljs.exec('npm install --save ' + dependencies[key]))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --save ` + dependencies[key]))) {
                     hasError = true;
                 }
             } else {
-                if (shelljs.error(shelljs.exec('npm install --save ' + key))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --save ` + key))) {
                     hasError = true;
                 }
             }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -1,11 +1,11 @@
 const shelljs = require('shelljs');
 const path = require('path');
 const shelfPath = require('./paths').shelfPath
-const nodePath = require('./paths').nodePath
-const moduleParentPath = path.dirname(nodePath)
+const installationPath = require('./paths').installationPath
+const moduleParentPath = path.dirname(installationPath)
+
 module.exports =
     function (dependencies) {
-        console.log(" **************  Node Path: "+ nodePath)
         shelljs.cd(shelfPath);
         let hasError = false;
         for (let key in dependencies) {

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -7,11 +7,11 @@ module.exports =
         let hasError = false;
         for (let key in dependencies) {
             if (dependencies[key].startsWith('http') || dependencies[key].startsWith('https')) {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --save ` + dependencies[key]))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --no-package-lock ` + dependencies[key]))) {
                     hasError = true;
                 }
             } else {
-                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --save ` + key))) {
+                if (shelljs.error(shelljs.exec(`npm install --prefix ${nodePath} --no-package-lock ` + key))) {
                     hasError = true;
                 }
             }

--- a/lib/downloadasset.js
+++ b/lib/downloadasset.js
@@ -1,37 +1,35 @@
 const download = require('download')
 const path = require('path')
 const fs = require('fs-extra')
-
+const shelfPath = require('./paths').shelfPath
+const logger = require('./logger')
 module.exports = {
     /*
     ** This method downloads the file from the URL
     ** specified in the parameters
     */
-    download_files : function(baseUrl, urls, basePath, idPath) {
+    download_files : function(baseUrl, urls, basePath, koAddress) {
       let requests = [];
       if(!baseUrl.endsWith('/')) {
         baseUrl = baseUrl + '/';
       }
       if(Array.isArray(urls)){
         urls.forEach(function(e) {
-          requests.push(constructPathsAndDownload(idPath, e, baseUrl, basePath));
+          requests.push(constructPathsAndDownload(koAddress, e, baseUrl, basePath));
         });
       } else {
-        requests.push(constructPathsAndDownload(idPath, urls, baseUrl, basePath));
+        requests.push(constructPathsAndDownload(koAddress, urls, baseUrl, basePath));
       }
       return requests;
-    },
-    cleanup: function(basePath, idPath){
-      fs.removeSync(path.join(basePath, idPath));
     }
 };
 
-function constructPathsAndDownload(idPath, e, baseUrl, basePath) {
-  let filePath = idPath;
+function constructPathsAndDownload(koAddress, e, baseUrl, basePath) {
+  let filePath = koAddress;
   let aUrl = "";
   let  assetURL = new URL(e, baseUrl);
   aUrl = assetURL.href;
-  filePath = path.dirname(path.join(idPath, e));
+  filePath = path.dirname(path.join(koAddress, e));
   return (downloadPromise(aUrl, basePath, filePath));
 }
 
@@ -42,12 +40,19 @@ function downloadPromise (asset_url, basePath, filePath) {
     if(path.extname(filename)!='.zip'){
       basePath=path.join(basePath, filePath);
     }
-    download(asset_url, basePath, {'extract':true, 'filename':filename})
-    .then(() => {
-      resolve(asset_url);
-    }).catch((error)=>{
-      console.log(error)
-      reject(asset_url)
-    });
+    let artifactName = path.join(shelfPath,filePath,filename)
+    if(fs.existsSync(artifactName)){
+      logger('debug',"Found Artifact: " + artifactName);
+      resolve(artifactName);
+    } else {
+      download(asset_url, basePath, {'extract': true, 'filename': filename})
+          .then(() => {
+            logger('debug',"Downloaded Artifact: " + artifactName);
+            resolve(asset_url);
+          }).catch((error) => {
+            console.log(error)
+            reject(asset_url)
+          });
+    }
   });
 }

--- a/lib/downloadasset.js
+++ b/lib/downloadasset.js
@@ -2,7 +2,7 @@ const download = require('download')
 const path = require('path')
 const fs = require('fs-extra')
 const shelfPath = require('./paths').shelfPath
-const logger = require('./logger')
+const log = require('./logger')
 module.exports = {
     /*
     ** This method downloads the file from the URL
@@ -42,15 +42,15 @@ function downloadPromise (asset_url, basePath, filePath) {
     }
     let artifactName = path.join(shelfPath,filePath,filename)
     if(fs.existsSync(artifactName)){
-      logger('debug',"Found Artifact: " + artifactName);
+      log('debug',"Found Artifact: " + artifactName);
       resolve(artifactName);
     } else {
       download(asset_url, basePath, {'extract': true, 'filename': filename})
           .then(() => {
-            logger('debug',"Downloaded Artifact: " + artifactName);
+            log('debug',"Downloaded Artifact: " + artifactName);
             resolve(asset_url);
           }).catch((error) => {
-            console.log(error)
+            log('error',error)
             reject(asset_url)
           });
     }

--- a/lib/findEndpoint.js
+++ b/lib/findEndpoint.js
@@ -1,0 +1,19 @@
+module.exports = function (key, req) {
+    let endpoint = global.cxt.map[key];
+    let baseUrl = req.app.locals.info.url;
+    let url;
+    if (baseUrl.endsWith('/')) {
+        url = baseUrl + key;
+    } else {
+        url = baseUrl + '/' + key;
+    }
+    epObj = {
+        "id": endpoint.id,
+        "activated": endpoint.activated,
+        "status": endpoint.status
+    }
+    if (endpoint.status === "Activated") {
+        epObj.url = url;
+    }
+    return epObj;
+}

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -11,6 +11,5 @@ let shelfPath = process.env.KGRID_NODE_SHELF_PATH
     ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
     : path.join(process.cwd(), 'shelf');
 let contextFilePath = path.join(shelfPath, "context.json");
-let packageFilePath = path.join(shelfPath, "package.json");
 
-module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, packageFilePath};
+module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -9,7 +9,7 @@ const environmentSelfUrl = process.env.KGRID_NODE_ENV_URL || configJSON.kgrid_no
 let shelfPath = process.env.KGRID_NODE_SHELF_PATH
     ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
     : path.join(process.cwd(), 'shelf');
-let installationPath = path.join(process.cwd(), 'kgrid_node', 'node_modules');
+let installationPath = path.join(process.cwd(), 'kgrid_node');
 let contextFilePath = path.join(process.cwd(), "kgrid_node", "context.json");
 
 module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, installationPath};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -10,6 +10,9 @@ const environmentSelfUrl = process.env.KGRID_NODE_ENV_URL || configJSON.kgrid_no
 let shelfPath = process.env.KGRID_NODE_SHELF_PATH
     ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
     : path.join(process.cwd(), 'shelf');
+let nodePath = process.env.NODE_PATH
+    ? path.join(process.env.NODE_PATH)
+    : path.join(shelfPath);
 let contextFilePath = path.join(shelfPath, "context.json");
 
-module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath};
+module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, nodePath};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -7,12 +7,13 @@ if (kgridProxyAdapterUrl.endsWith("/")) {
 }
 
 const environmentSelfUrl = process.env.KGRID_NODE_ENV_URL || configJSON.kgrid_node_env_url;
+console.log("Current Working Directory: "+process.cwd())
 let shelfPath = process.env.KGRID_NODE_SHELF_PATH
     ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
     : path.join(process.cwd(), 'shelf');
 let nodePath = process.env.NODE_PATH
-    ? path.join(process.env.NODE_PATH)
-    : path.join(shelfPath);
-let contextFilePath = path.join(shelfPath, "context.json");
+    ? path.join(process.cwd(), process.env.NODE_PATH)
+    : path.join(process.cwd(), "kgrid_node", "node_modules");
+let contextFilePath = path.join(process.cwd(), "kgrid_node", "context.json");
 
 module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, nodePath};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -5,15 +5,11 @@ let kgridProxyAdapterUrl = process.env.KGRID_PROXY_ADAPTER_URL || configJSON.kgr
 if (kgridProxyAdapterUrl.endsWith("/")) {
     kgridProxyAdapterUrl = kgridProxyAdapterUrl.substr(0, kgridProxyAdapterUrl.length - 1);
 }
-
 const environmentSelfUrl = process.env.KGRID_NODE_ENV_URL || configJSON.kgrid_node_env_url;
-console.log("Current Working Directory: "+process.cwd())
 let shelfPath = process.env.KGRID_NODE_SHELF_PATH
     ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
     : path.join(process.cwd(), 'shelf');
-let nodePath = process.env.NODE_PATH
-    ? path.join(process.cwd(), process.env.NODE_PATH)
-    : path.join(process.cwd(), "kgrid_node", "node_modules");
+let installationPath = path.join(process.cwd(), 'kgrid_node', 'node_modules');
 let contextFilePath = path.join(process.cwd(), "kgrid_node", "context.json");
 
-module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, nodePath};
+module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, installationPath};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const configJSON = require('../appProperties.json')
+
+let kgridProxyAdapterUrl = process.env.KGRID_PROXY_ADAPTER_URL || configJSON.kgrid_proxy_adapter_url;
+if (kgridProxyAdapterUrl.endsWith("/")) {
+    kgridProxyAdapterUrl = kgridProxyAdapterUrl.substr(0, kgridProxyAdapterUrl.length - 1);
+}
+
+const environmentSelfUrl = process.env.KGRID_NODE_ENV_URL || configJSON.kgrid_node_env_url;
+let shelfPath = process.env.KGRID_NODE_SHELF_PATH
+    ? path.join(process.cwd(), process.env.KGRID_NODE_SHELF_PATH)
+    : path.join(process.cwd(), 'shelf');
+let contextFilePath = path.join(shelfPath, "context.json");
+let packageFilePath = path.join(shelfPath, "package.json");
+
+module.exports = {kgridProxyAdapterUrl, environmentSelfUrl, shelfPath, contextFilePath, packageFilePath};

--- a/lib/registration.js
+++ b/lib/registration.js
@@ -1,0 +1,31 @@
+const pjson = require('./../package.json');
+const kgridProxyAdapterUrl = require('../lib/paths').kgridProxyAdapterUrl
+const environmentSelfUrl = require('../lib/paths').environmentSelfUrl
+const axios = require('axios').default;
+const log = require('./logger')
+
+module.exports = function (app, forceUpdate) {
+    let reqBody = {};
+    reqBody.engine = 'node';
+    reqBody.version = pjson.version
+    reqBody.url = environmentSelfUrl
+    reqBody.contextKeys = Object.keys(global.cxt.map);
+    reqBody.forceUpdate = forceUpdate;
+    axios.post(kgridProxyAdapterUrl + "/proxy/environments",
+        reqBody)
+        .then(function (response) {
+            log(
+                forceUpdate ? 'info' : 'debug',
+                `Registered remote environment in activator at ${kgridProxyAdapterUrl} with response: ${JSON.stringify(response.data)}`)
+            app.locals.info.activatorUrl = kgridProxyAdapterUrl;
+        })
+        .catch(function (error) {
+            if (error.response) {
+                log('warn', error.response.data);
+                log('debug', error);
+            } else {
+                log('warn', error.message);
+                log('debug', error);
+            }
+        });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kgrid/noderuntime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9765,6 +9765,12 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kgrid/noderuntime",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9308,8 +9308,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -11378,7 +11377,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "http-errors": "~1.6.3",
     "pug": "^3.0.1",
     "shelljs": "^0.8.4",
+    "uri-js": "^4.4.1",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kgrid/noderuntime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "KGrid Node Runtime",
   "author": "kgrid",
   "repository": {
@@ -12,8 +12,9 @@
     "kgrid-node": "./bin/www"
   },
   "scripts": {
-    "start": "export NODE_PATH=$(pwd)/kgrid_node/node_modules && node ./bin/www",
-    "winstart": "set NODE_PATH=%cd%\\kgrid_node\\node_modules&& node ./bin/www",
+    "start": "run-script-os",
+    "start:linux:darwin": "export NODE_PATH=$(pwd)/kgrid_node/node_modules && node ./bin/www",
+    "start:win32": "set NODE_PATH=%cd%\\kgrid_node\\node_modules&& node ./bin/www",
     "debug": "nodemon --inspect ./bin/www",
     "test": "mocha --exit --timeout 10000",
     "docs:dev": "vuepress dev docs -p 3000",
@@ -42,6 +43,7 @@
     "chai-http": "^4.3.0",
     "mocha": "^7.2.0",
     "nodemon": "^2.0.6",
+    "run-script-os": "^1.1.6",
     "vuepress": "^1.8.2"
   },
   "nodemonConfig": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "start": "export NODE_PATH=$(pwd)/kgrid_node/node_modules && node ./bin/www",
+    "winstart": "set NODE_PATH=%cd%\\kgrid_node\\node_modules&& node ./bin/www",
     "debug": "nodemon --inspect ./bin/www",
     "test": "mocha --exit --timeout 10000",
     "docs:dev": "vuepress dev docs -p 3000",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "kgrid-node": "./bin/www"
   },
   "scripts": {
-    "start": "node ./bin/www",
+    "start": "export NODE_PATH=$(pwd)/kgrid_node/node_modules && node ./bin/www",
     "debug": "nodemon --inspect ./bin/www",
     "test": "mocha --exit --timeout 10000",
     "docs:dev": "vuepress dev docs -p 3000",

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,0 @@
-let express = require('express');
-let router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;


### PR DESCRIPTION
- Node runtime can now use an external shelf on the same filesystem, by setting KGRID_NODE_SHELF_PATH environment variable to a path relative to where the node runtime is running from. 
- Starting the Node runtime now sets the NODE_PATH environment variable, enabling using a read-only external shelf. (For starting the release, the user will have to set NODE_PATH to where they want KO dependencies to be stored)